### PR TITLE
fix emg redirection to include slash

### DIFF
--- a/emg/.htaccess
+++ b/emg/.htaccess
@@ -21,19 +21,23 @@ RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
 
 # emg v2.0.0 docs
 RewriteRule ^v2.0.0$  https://owl.emglossary.helmholtz-metadaten.de/  [R=303,L]
+RewriteRule ^v2.0.0/$  https://owl.emglossary.helmholtz-metadaten.de/  [R=303,L]
 RewriteRule ^v2.0.0/(EMG_[0-9]+)$ https://owl.emglossary.helmholtz-metadaten.de/index.html#$1  [R=303,NE,L]
 
 # emg v2.0.0 owl
 RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*
+RewriteRule ^v2.0.0$ https://codebase.helmholtz.cloud/em_glossary/em_glossary_owl/-/raw/main/emg.owl [R=303,L]
 RewriteRule ^v2.0.0/$ https://codebase.helmholtz.cloud/em_glossary/em_glossary_owl/-/raw/main/emg.owl [R=303,L]
 RewriteRule ^v2.0.0/(EMG_[0-9]+)$ https://codebase.helmholtz.cloud/em_glossary/em_glossary_owl/-/raw/main/emg.owl  [R=303,NE,L]
 
 # emg v1.0.0 docs
 RewriteRule ^v1.0.0$  https://codebase.helmholtz.cloud/em_glossary/em_glossary_owl/-/raw/main/previous-versions/v1.0.0/emg.owl  [R=303,L]
+RewriteRule ^v1.0.0/$  https://codebase.helmholtz.cloud/em_glossary/em_glossary_owl/-/raw/main/previous-versions/v1.0.0/emg.owl  [R=303,L]
 
 # emg previous versions owl
 RewriteCond %{HTTP_ACCEPT} ^.*application/rdf\+xml.*
 RewriteRule ^v1.0.0$ https://codebase.helmholtz.cloud/em_glossary/em_glossary_owl/-/raw/main/previous-versions/v1.0.0/emg.owl [R=303,L]
+RewriteRule ^v1.0.0/$ https://codebase.helmholtz.cloud/em_glossary/em_glossary_owl/-/raw/main/previous-versions/v1.0.0/emg.owl [R=303,L]
 RewriteRule ^v1.0.0/(EMG_[0-9]+)$ https://codebase.helmholtz.cloud/em_glossary/em_glossary_owl/-/raw/main/previous-versions/v1.0.0/emg.owl  [R=303,NE,L]
 
 # HTML ontology docs


### PR DESCRIPTION
as per your request @hofmannv, I adapted the rules to make both  https://purls.helmholtz-metadaten.de/emg/v1.0.0 and https://purls.helmholtz-metadaten.de/emg/v1.0.0/ work (and v2 also).